### PR TITLE
Исправление исключения при парсинге Status Code

### DIFF
--- a/xNet/~Http/HttpResponse.cs
+++ b/xNet/~Http/HttpResponse.cs
@@ -1255,6 +1255,12 @@ namespace xNet
             string version = startingLine.Substring("HTTP/", " ");
             string statusCode = startingLine.Substring(" ", " ");
 
+            if (statusCode.Length == 0)
+            {
+                // Если сервер не возвращает Reason Phrase
+                statusCode = startingLine.Substring(" ", Http.NewLine);
+            }
+
             if (version.Length == 0 || statusCode.Length == 0)
             {
                 throw NewHttpException(Resources.HttpException_ReceivedEmptyResponse);


### PR DESCRIPTION
Исправил ошибку, когда вызывалось исключение при парсинге Status Code,
если в ответе сервера не было Reason Phrase. 
Пример "HTTP/1.1 200/r/n" на сайте http://api.temp-mail.ru/request/domains/