### PR TITLE
Fix ReplaceUnicode()

### DIFF
--- a/xNet/Html.cs
+++ b/xNet/Html.cs
@@ -77,7 +77,7 @@ namespace xNet
                 return string.Empty;
             }
 
-            var regex = new Regex(@"\\[uU](?<text>[0-9A-F]{4})", RegexOptions.Compiled);
+            var regex = new Regex(@"\\u(?<code>[0-9a-f]{4})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
             string result = regex.Replace(str, match =>
             {


### PR DESCRIPTION
1. Устранен баг, из-за которого ReplaceUnicode() всегда вызывало исключение
2. Добавлена поддержка Unicode-сущностей в нижнем регистре, например \u044f