### PR TITLE
Added several 4XX and 5XX status codes

### DIFF
--- a/xNet/~Http/HttpStatusCode.cs
+++ b/xNet/~Http/HttpStatusCode.cs
@@ -51,6 +51,11 @@ namespace xNet
         UnsupportedMediaType = 415,
         RequestedRangeNotSatisfiable = 416,
         ExpectationFailed = 417,
+        UpgradeRequired = 426,
+        PreconditionRequired = 428,
+        TooManyRequests = 429,
+        RequestHeaderFieldsTooLarge = 431,
+        UnavailableForLegalReasons = 451,
 
         InternalServerError = 500,
         NotImplemented = 501,
@@ -58,5 +63,6 @@ namespace xNet
         ServiceUnavailable = 503,
         GatewayTimeout = 504,
         HttpVersionNotSupported = 505,
+        NetworkAuthenticationRequired = 511,
     }
 }


### PR DESCRIPTION
Added following missing HTTP status codes

- 426 Upgrade Required
-  428 Precondition Required
- 429 Too Many Requests
- 431 Request Header Fields Too Large
- 451 Unavailable For Legal Reasons
- 511 Network Authentication Required

Codes and text was taken from https://developer.mozilla.org/en-US/docs/Web/HTTP/Status